### PR TITLE
project structure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  SplitEmptyRecord: false
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+AlignAfterOpenBracket: DontAlign
+IncludeCategories:
+  - Regex: '^"pch\.h"$'
+    Priority: 0
+  - Regex: '.*'
+    Priority: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(zen_remote_display_system LANGUAGES C CXX VERSION 0.1.0.1)
+
+set (CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set (required_version ${REQUIRED_ZEN_REMOTE_DISPLAY_SYSTEM_VERSION})
+
+if(required_version AND (required_version VERSION_GREATER PROJECT_VERSION))
+  message(
+    FATAL_ERROR 
+    "ZEN Remote Display System is required to be version ${required_version}, \
+but is ${PROJECT_VERSION}"
+    )
+endif()
+
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+add_compile_options(-Wall -Winvalid-pch -Wextra -Wpedantic -Werror)
+
+add_subdirectory(client)
+add_subdirectory(server)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB_RECURSE CLIENT_SOURCE CONFIGURE_DEPENDS ./*.cc)
+file(GLOB_RECURSE CORE_SOURCE CONFIGURE_DEPENDS ../core/*.cc)
+
+add_library(
+    zen_remote_display_system_client STATIC 
+    ${CLIENT_SOURCE}
+    ${CORE_SOURCE}
+)
+
+target_include_directories(
+    zen_remote_display_system_client
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    PRIVATE ../core
+)
+
+target_compile_options(
+    zen_remote_display_system_client
+    PRIVATE -Wno-gnu-zero-variadic-macro-arguments
+)
+
+add_library(zen_remote_display_system::client ALIAS zen_remote_display_system_client)

--- a/client/session.cc
+++ b/client/session.cc
@@ -1,0 +1,20 @@
+#include "session.h"
+
+#include "logger.h"
+
+namespace zen::display_system::remote::client {
+
+bool
+Session::Init()
+{
+  LOG_INFO("Remote Display System Session Client Initialized");
+  return true;
+}
+
+std::unique_ptr<ISession>
+SessionCreate()
+{
+  return std::make_unique<Session>();
+}
+
+}  // namespace zen::display_system::remote::client

--- a/client/session.h
+++ b/client/session.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <zen/display-system/remote/client.h>
+
+namespace zen::display_system::remote::client {
+
+class Session : public ISession {
+ public:
+  bool Init() override;
+};
+
+}  // namespace zen::display_system::remote::client

--- a/core/common.h
+++ b/core/common.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace {
+
+#define DISABLE_MOVE_AND_COPY(Class)        \
+  Class(const Class &) = delete;            \
+  Class(Class &&) = delete;                 \
+  Class &operator=(const Class &) = delete; \
+  Class &operator=(Class &&) = delete
+
+}  // namespace

--- a/core/logger.cc
+++ b/core/logger.cc
@@ -1,0 +1,27 @@
+#include "logger.h"
+
+#include <stdarg.h>
+#include <zen/display-system/remote/core/logger.h>
+
+namespace zen::display_system::remote::log {
+
+void
+Logger::Print(Severity severity, const char* pretty_function, const char* file,
+    int line, const char* format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  if (sink_) sink_->Sink(severity, pretty_function, file, line, format, args);
+  va_end(args);
+}
+
+std::unique_ptr<Logger> Logger::instance;
+
+void
+InitializeLogger(std::unique_ptr<ILogSink> sink)
+{
+  Logger::instance = std::make_unique<Logger>();
+  Logger::instance->sink_ = std::move(sink);
+}
+
+}  // namespace zen::display_system::remote::log

--- a/core/logger.h
+++ b/core/logger.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "common.h"
+#include <memory>
+#include <zen/display-system/remote/core/logger.h>
+
+namespace zen::display_system::remote::log {
+
+struct Logger {
+  // logger singleton set by InitializeLogger;
+  static std::unique_ptr<Logger> instance;
+
+  DISABLE_MOVE_AND_COPY(Logger);
+  Logger() = default;
+  virtual ~Logger() = default;
+
+  void Print(Severity severity, const char* pretty_function, const char* file,
+      int line, const char* format, ...)
+      __attribute__((__format__(printf, 6, 7)));
+
+ private:
+  friend void InitializeLogger(std::unique_ptr<ILogSink> sink);
+  std::unique_ptr<ILogSink> sink_;
+};
+
+#define LOG_DEBUG(format, ...)                                                \
+  zen::display_system::remote::log::Logger::instance->Print(                  \
+      zen::display_system::remote::log::DEBUG, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_INFO(format, ...)                                                \
+  zen::display_system::remote::log::Logger::instance->Print(                 \
+      zen::display_system::remote::log::INFO, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_WARN(format, ...)                                                \
+  zen::display_system::remote::log::Logger::instance->Print(                 \
+      zen::display_system::remote::log::WARN, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_ERROR(format, ...)                                                \
+  zen::display_system::remote::log::Logger::instance->Print(                  \
+      zen::display_system::remote::log::ERROR, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_FATAL(format, ...)                                                \
+  zen::display_system::remote::log::Logger::instance->Print(                  \
+      zen::display_system::remote::log::FATAL, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+}  // namespace zen::display_system::remote::log

--- a/include/zen/display-system/remote/client.h
+++ b/include/zen/display-system/remote/client.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace zen::display_system::remote::client {
+
+struct ISession {
+  virtual ~ISession() = default;
+
+  virtual bool Init() = 0;
+};
+
+std::unique_ptr<ISession> SessionCreate();
+
+}  // namespace zen::display_system::remote::client

--- a/include/zen/display-system/remote/core/logger.h
+++ b/include/zen/display-system/remote/core/logger.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <stdarg.h>
+
+namespace zen::display_system::remote::log {
+
+typedef enum Severity {
+  DEBUG = 0,  // logs for debugging during development.
+  INFO,       // logs that may be useful to some users.
+  WARN,       // logs for recoverable failures.
+  ERROR,      // logs for unrecoverable failures.
+  FATAL,      // logs when aborting.
+  SILENT,     // for internal use only.
+} Severity;
+
+struct ILogSink {
+  virtual ~ILogSink() = default;
+
+  virtual void Sink(Severity severity, const char* pretty_function,
+      const char* file, int line, const char* format, va_list vp) = 0;
+};
+
+void InitializeLogger(std::unique_ptr<ILogSink> sink);
+
+}  // namespace zen::display_system::remote::log

--- a/include/zen/display-system/remote/server.h
+++ b/include/zen/display-system/remote/server.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace zen::display_system::remote::server {
+
+struct ISession {
+  virtual ~ISession() = default;
+
+  virtual bool Init() = 0;
+};
+
+std::unique_ptr<ISession> SessionCreate();
+
+}  // namespace zen::display_system::remote::server

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB_RECURSE SERVER_SOURCE CONFIGURE_DEPENDS ./*.cc)
+file(GLOB_RECURSE CORE_SOURCE CONFIGURE_DEPENDS ../core/*.cc)
+
+add_library(
+    zen_remote_display_system_server STATIC 
+    ${SERVER_SOURCE}
+    ${CORE_SOURCE}
+)
+
+target_include_directories(
+    zen_remote_display_system_server
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    PRIVATE ../core
+)
+
+target_compile_options(
+    zen_remote_display_system_server
+    PRIVATE -Wno-gnu-zero-variadic-macro-arguments
+)
+
+add_library(zen_remote_display_system::server ALIAS zen_remote_display_system_server)

--- a/server/session.cc
+++ b/server/session.cc
@@ -1,0 +1,20 @@
+#include "session.h"
+
+#include "logger.h"
+
+namespace zen::display_system::remote::server {
+
+bool
+Session::Init()
+{
+  LOG_INFO("Remote Display System Session Server Initialized");
+  return true;
+}
+
+std::unique_ptr<ISession>
+SessionCreate()
+{
+  return std::make_unique<Session>();
+}
+
+}  // namespace zen::display_system::remote::server

--- a/server/session.h
+++ b/server/session.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <zen/display-system/remote/server.h>
+
+namespace zen::display_system::remote::server {
+
+class Session : public ISession {
+ public:
+  bool Init() override;
+};
+
+}  // namespace zen::display_system::remote::server


### PR DESCRIPTION
## Context

ZEN Remote Display System will be used both in zen(server) and Oculus Quest(client).
So it must be able to be built on both platform.

## Summary

- [x] Create static library for both side
- [x] Enable to check version via `REQUIRED_ZEN_REMOTE_DISPLAY_SYSTEM_VERSION` cmake variable. 

## How to check behavior

Nothing to check.