### PR TITLE
Inlcude boost headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,13 @@ endif()
 
 add_compile_options(-Wall -Winvalid-pch -Wextra -Wpedantic -Werror)
 
+include(FetchContent)
+FetchContent_Declare(
+  boost_headers_content
+  GIT_REPOSITORY https://github.com/zigen-project/boost-headers.git
+  GIT_TAG boost-1.80.0
+)
+FetchContent_MakeAvailable(boost_headers_content)
+
 add_subdirectory(client)
 add_subdirectory(server)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -11,7 +11,10 @@ target_include_directories(
     zen_remote_display_system_client
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
     PRIVATE ../core
+    PRIVATE ${boost_headers_content_SOURCE_DIR}/include
 )
+
+target_precompile_headers(zen_remote_display_system_client PRIVATE ../core/pch.h)
 
 target_compile_options(
     zen_remote_display_system_client

--- a/client/session.cc
+++ b/client/session.cc
@@ -1,6 +1,7 @@
-#include "session.h"
+#include "pch.h"
 
 #include "logger.h"
+#include "session.h"
 
 namespace zen::display_system::remote::client {
 

--- a/client/session.h
+++ b/client/session.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <zen/display-system/remote/client.h>
+#include "zen/display-system/remote/client.h"
 
 namespace zen::display_system::remote::client {
 

--- a/core/logger.cc
+++ b/core/logger.cc
@@ -1,7 +1,7 @@
-#include "logger.h"
+#include "pch.h"
 
-#include <stdarg.h>
-#include <zen/display-system/remote/core/logger.h>
+#include "logger.h"
+#include "zen/display-system/remote/core/logger.h"
 
 namespace zen::display_system::remote::log {
 

--- a/core/logger.h
+++ b/core/logger.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "common.h"
-#include <memory>
-#include <zen/display-system/remote/core/logger.h>
+#include "zen/display-system/remote/core/logger.h"
 
 namespace zen::display_system::remote::log {
 

--- a/core/pch.h
+++ b/core/pch.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <memory>
+#include <stdarg.h>

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -11,7 +11,10 @@ target_include_directories(
     zen_remote_display_system_server
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
     PRIVATE ../core
+    PRIVATE ${boost_headers_content_SOURCE_DIR}/include
 )
+
+target_precompile_headers(zen_remote_display_system_server PRIVATE ../core/pch.h)
 
 target_compile_options(
     zen_remote_display_system_server

--- a/server/session.cc
+++ b/server/session.cc
@@ -1,6 +1,7 @@
-#include "session.h"
+#include "pch.h"
 
 #include "logger.h"
+#include "session.h"
 
 namespace zen::display_system::remote::server {
 

--- a/server/session.h
+++ b/server/session.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <zen/display-system/remote/server.h>
+#include "zen/display-system/remote/server.h"
 
 namespace zen::display_system::remote::server {
 


### PR DESCRIPTION
## Context

Enable to use Boost header libraries.

## Summary

- [x] Fetch content of https://github.com/zigen-project/boost-headers
- [x] Configure the Boost header libraries.
- [x] Fix `#include` usage (using pch.h)  

## How to check behavior

Nothing to do.
